### PR TITLE
Introduce new pattern for is_valid_removal

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -638,6 +638,11 @@ class SubListCreateAttachDetachAPIView(SubListCreateAPIView):
     # attaching/detaching them from the parent.
 
     def is_valid_relation(self, parent, sub, created=False):
+        "Override in subclasses to do efficient validation of attaching"
+        return None
+
+    def is_valid_removal(self, parent, sub):
+        "Same as is_valid_relation but called on disassociation"
         return None
 
     def get_description_context(self):
@@ -721,6 +726,11 @@ class SubListCreateAttachDetachAPIView(SubListCreateAPIView):
 
         if not request.user.can_access(self.parent_model, 'unattach', parent, sub, self.relationship, request.data):
             raise PermissionDenied()
+
+        # Verify that removing the relationship is valid.
+        unattach_errors = self.is_valid_removal(parent, sub)
+        if unattach_errors is not None:
+            return Response(unattach_errors, status=status.HTTP_400_BAD_REQUEST)
 
         if parent_key:
             sub.delete()

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -404,11 +404,23 @@ class InstanceInstanceGroupsList(InstanceGroupMembershipMixin, SubListCreateAtta
     parent_model = models.Instance
     relationship = 'rampart_groups'
 
+    def unattach_validate(self, request):
+        sub_id, res = super().unattach_validate(request)
+        if res:
+            return (sub_id, res)
+        parent = self.get_parent_object()
+        sub = get_object_or_400(self.model, pk=sub_id)
+        if sub.name == 'controlplane' and parent.node_type == 'hybrid':
+            data = dict({'msg': _(f"Cannot disassociate hybrid instance {parent.hostname} from controlplane.")})
+            res = Response(data, status=status.HTTP_400_BAD_REQUEST)
+            return (sub_id, res)
+        return (sub_id, res)
+
     def is_valid_relation(self, parent, sub, created=False):
         if parent.node_type == 'control':
             return {'msg': _(f"Cannot change instance group membership of control-only node: {parent.hostname}.")}
         if parent.node_type == 'hop':
-            return {'msg': _(f"Cannot change instance group membership of hop node: {parent.hostname}.")}
+            return {'msg': _(f"Cannot change instance group membership of hop node : {parent.hostname}.")}
         return None
 
 
@@ -505,6 +517,18 @@ class InstanceGroupInstanceList(InstanceGroupMembershipMixin, SubListAttachDetac
     parent_model = models.InstanceGroup
     relationship = "instances"
     search_fields = ('hostname',)
+
+    def unattach_validate(self, request):
+        sub_id, res = super().unattach_validate(request)
+        if res:
+            return (sub_id, res)
+        parent = self.get_parent_object()
+        sub = get_object_or_400(self.model, pk=sub_id)
+        if sub.node_type == 'hybrid' and parent.name == 'controlplane':
+            data = dict({'msg': _(f"Cannot disassociate hybrid node {sub.hostname} from controlplane.")})
+            res = Response(data, status=status.HTTP_400_BAD_REQUEST)
+            return (sub_id, res)
+        return (sub_id, res)
 
     def is_valid_relation(self, parent, sub, created=False):
         if sub.node_type == 'control':

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -404,23 +404,19 @@ class InstanceInstanceGroupsList(InstanceGroupMembershipMixin, SubListCreateAtta
     parent_model = models.Instance
     relationship = 'rampart_groups'
 
-    def unattach_validate(self, request):
-        sub_id, res = super().unattach_validate(request)
-        if res:
-            return (sub_id, res)
-        parent = self.get_parent_object()
-        sub = get_object_or_400(self.model, pk=sub_id)
-        if sub.name == 'controlplane' and parent.node_type == 'hybrid':
-            data = dict({'msg': _(f"Cannot disassociate hybrid instance {parent.hostname} from controlplane.")})
-            res = Response(data, status=status.HTTP_400_BAD_REQUEST)
-            return (sub_id, res)
-        return (sub_id, res)
-
     def is_valid_relation(self, parent, sub, created=False):
         if parent.node_type == 'control':
             return {'msg': _(f"Cannot change instance group membership of control-only node: {parent.hostname}.")}
         if parent.node_type == 'hop':
             return {'msg': _(f"Cannot change instance group membership of hop node : {parent.hostname}.")}
+        return None
+
+    def is_valid_removal(self, parent, sub):
+        res = self.is_valid_relation(parent, sub)
+        if res:
+            return res
+        if sub.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME and parent.node_type == 'hybrid':
+            return {'msg': _(f"Cannot disassociate hybrid instance {parent.hostname} from controlplane.")}
         return None
 
 
@@ -518,23 +514,19 @@ class InstanceGroupInstanceList(InstanceGroupMembershipMixin, SubListAttachDetac
     relationship = "instances"
     search_fields = ('hostname',)
 
-    def unattach_validate(self, request):
-        sub_id, res = super().unattach_validate(request)
-        if res:
-            return (sub_id, res)
-        parent = self.get_parent_object()
-        sub = get_object_or_400(self.model, pk=sub_id)
-        if sub.node_type == 'hybrid' and parent.name == 'controlplane':
-            data = dict({'msg': _(f"Cannot disassociate hybrid node {sub.hostname} from controlplane.")})
-            res = Response(data, status=status.HTTP_400_BAD_REQUEST)
-            return (sub_id, res)
-        return (sub_id, res)
-
     def is_valid_relation(self, parent, sub, created=False):
         if sub.node_type == 'control':
             return {'msg': _(f"Cannot change instance group membership of control-only node: {sub.hostname}.")}
         if sub.node_type == 'hop':
             return {'msg': _(f"Cannot change instance group membership of hop node: {sub.hostname}.")}
+        return None
+
+    def is_valid_removal(self, parent, sub):
+        res = self.is_valid_relation(parent, sub)
+        if res:
+            return res
+        if sub.node_type == 'hybrid' and parent.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME:
+            return {'msg': _(f"Cannot disassociate hybrid node {sub.hostname} from controlplane.")}
         return None
 
 

--- a/awx/ui/src/components/DisassociateButton/DisassociateButton.js
+++ b/awx/ui/src/components/DisassociateButton/DisassociateButton.js
@@ -18,6 +18,7 @@ function DisassociateButton({
   modalTitle = t`Disassociate?`,
   onDisassociate,
   verifyCannotDisassociate = true,
+  isProtectedInstanceGroup = false,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const { isKebabified, onKebabModalChange } = useContext(KebabifiedContext);
@@ -37,7 +38,10 @@ function DisassociateButton({
     return !item.summary_fields?.user_capabilities?.delete;
   }
   function cannotDisassociateInstances(item) {
-    return item.node_type === 'control';
+    return (
+      item.node_type === 'control' ||
+      (isProtectedInstanceGroup && item.node_type === 'hybrid')
+    );
   }
 
   const cannotDisassociate = itemsToDisassociate.some(
@@ -73,11 +77,7 @@ function DisassociateButton({
 
   let isDisabled = false;
   if (verifyCannotDisassociate) {
-    isDisabled =
-      itemsToDisassociate.length === 0 ||
-      itemsToDisassociate.some(cannotDisassociate);
-  } else {
-    isDisabled = itemsToDisassociate.length === 0;
+    isDisabled = itemsToDisassociate.some(cannotDisassociate);
   }
 
   // NOTE: Once PF supports tooltips on disabled elements,
@@ -89,7 +89,7 @@ function DisassociateButton({
         <DropdownItem
           key="add"
           aria-label={t`disassociate`}
-          isDisabled={isDisabled}
+          isDisabled={isDisabled || !itemsToDisassociate.length}
           component="button"
           ouiaId="disassociate-tooltip"
           onClick={() => setIsOpen(true)}
@@ -108,7 +108,7 @@ function DisassociateButton({
               variant="secondary"
               aria-label={t`Disassociate`}
               onClick={() => setIsOpen(true)}
-              isDisabled={isDisabled}
+              isDisabled={isDisabled || !itemsToDisassociate.length}
             >
               {t`Disassociate`}
             </Button>

--- a/awx/ui/src/components/DisassociateButton/DisassociateButton.test.js
+++ b/awx/ui/src/components/DisassociateButton/DisassociateButton.test.js
@@ -124,5 +124,21 @@ describe('<DisassociateButton />', () => {
       );
       expect(wrapper.find('button[disabled]')).toHaveLength(1);
     });
+    test('should disable button when selected items contain instances thaat are hybrid and are inside a protected instances', () => {
+      const wrapper = mountWithContexts(
+        <DisassociateButton
+          onDisassociate={() => {}}
+          isProectedInstanceGroup
+          itemsToDelete={[
+            {
+              id: 1,
+              hostname: 'awx',
+              node_type: 'control',
+            },
+          ]}
+        />
+      );
+      expect(wrapper.find('button[disabled]')).toHaveLength(1);
+    });
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
@@ -275,10 +275,11 @@ function InstanceDetails({ setBreadcrumb, instanceGroup }) {
           </Tooltip>
           {me.is_superuser && instance.node_type !== 'control' && (
             <DisassociateButton
-              verifyCannotDisassociate={!me.is_superuser}
+              verifyCannotDisassociate={instanceGroup.name === 'controlplane'}
               key="disassociate"
               onDisassociate={disassociateInstance}
               itemsToDisassociate={[instance]}
+              isProtectedInstanceGroup={instanceGroup.name === 'controlplane'}
               modalTitle={t`Disassociate instance from instance group?`}
             />
           )}

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -31,7 +31,7 @@ const QS_CONFIG = getQSConfig('instance', {
   order_by: 'hostname',
 });
 
-function InstanceList() {
+function InstanceList({ instanceGroup }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const location = useLocation();
   const { id: instanceGroupId } = useParams();
@@ -224,13 +224,15 @@ function InstanceList() {
                   ]
                 : []),
               <DisassociateButton
-                verifyCannotDisassociate={selected.some(
-                  (s) => s.node_type === 'control'
-                )}
+                verifyCannotDisassociate={
+                  selected.some((s) => s.node_type === 'control') ||
+                  instanceGroup.name === 'controlplane'
+                }
                 key="disassociate"
                 onDisassociate={handleDisassociate}
                 itemsToDisassociate={selected}
                 modalTitle={t`Disassociate instance from instance group?`}
+                isProtectedInstanceGroup={instanceGroup.name === 'controlplane'}
               />,
               <HealthCheckButton
                 isDisabled={!canAdd}

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
@@ -123,7 +123,7 @@ describe('<InstanceList/>', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <Route path="/instance_groups/:id/instances">
-          <InstanceList />
+          <InstanceList instanceGroup={{ name: 'Alex' }} />
         </Route>,
         {
           context: {

--- a/awx/ui/src/screens/InstanceGroup/Instances/Instances.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/Instances.js
@@ -21,7 +21,7 @@ function Instances({ setBreadcrumb, instanceGroup }) {
         />
       </Route>
       <Route key="instanceList" path="/instance_groups/:id/instances">
-        <InstanceList />
+        <InstanceList instanceGroup={instanceGroup} />
       </Route>
     </Switch>
   );

--- a/awx/ui/src/util/validators.js
+++ b/awx/ui/src/util/validators.js
@@ -186,8 +186,3 @@ export function regExp() {
     return undefined;
   };
 }
-
-export function protectedResourceName(message, names = []) {
-  return (value) =>
-    names.some((name) => value.trim() === `${name}`) ? message : undefined;
-}

--- a/awx/ui/src/util/validators.test.js
+++ b/awx/ui/src/util/validators.test.js
@@ -12,7 +12,6 @@ import {
   regExp,
   requiredEmail,
   validateTime,
-  protectedResourceName,
 } from './validators';
 
 describe('validators', () => {
@@ -187,22 +186,5 @@ describe('validators', () => {
     expect(validateTime()('12:15: PM')).toEqual('Invalid time format');
     expect(validateTime()('12.15 PM')).toEqual('Invalid time format');
     expect(validateTime()('12;15 PM')).toEqual('Invalid time format');
-  });
-  test('protectedResourceName should validate properly', () => {
-    expect(
-      protectedResourceName('failed validation', ['Alex'])('Apollo')
-    ).toBeUndefined();
-    expect(
-      protectedResourceName('failed validation', ['Alex', 'Athena'])('alex')
-    ).toBeUndefined();
-    expect(
-      protectedResourceName('failed validation', ['Alex', 'Athena'])('Alex')
-    ).toEqual('failed validation');
-    expect(
-      protectedResourceName('failed validation', ['Alex'])('Alex')
-    ).toEqual('failed validation');
-    expect(
-      protectedResourceName('failed validation', ['Alex'])('Alex ')
-    ).toEqual('failed validation');
   });
 });


### PR DESCRIPTION
##### SUMMARY
I feel like the level of hackiness was snowballing with these instance / IG endpoints, so I made this which adds something to the generic class.

I was not happy when `is_valid_relation` was added in the first place, because I didn't feel like it had the flexibility it would need long-term. This change is trying to follow the pattern it set as much as possible, but I think it's sufficiently tolerable.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

